### PR TITLE
Separate static and dynamic libs by filename

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,11 @@ endmacro()
 
 find_package(LibXml2 REQUIRED)
 
-build_lib(srcsax_static STATIC srcsax_static)
+if(WIN32)
+    build_lib(srcsax_static STATIC srcsax_static)
+else()
+    build_lib(srcsax_static STATIC srcsax)
+endif()
 target_link_libraries(srcsax_static PRIVATE LibXml2::LibXml2)
 
 build_lib(srcsax_shared SHARED srcsax)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,23 +8,24 @@ file(GLOB WINDOWS_INCLUDE windows/*.hpp)
 #  Used to help with the creation of the srcML library.
 #  - LIB_NAME is the name of the library and target
 #  - LIB_TYPE is either STATIC or SHARED.
+#  - LIB_OUTPUT_NAME is the output filename for the compiled library.
 # 
-macro(build_lib LIB_NAME LIB_TYPE)
+macro(build_lib LIB_NAME LIB_TYPE LIB_OUTPUT_NAME)
 
     add_library(${LIB_NAME} ${LIB_TYPE} ${HANDLER_SOURCE} ${HANDLER_INCLUDE} ${WINDOWS_SOURCE} ${WINDOWS_INCLUDE})
 
-if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
-    set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME libsrcsax LINK_FLAGS_DEBUG "/SAFESEH:NO")
-elseif(APPLE)
-    set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME srcsax MACOSX_RPATH OFF)
-else()
-    set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME srcsax)
-endif()
+    if("x${CMAKE_CXX_COMPILER_ID}" STREQUAL "xMSVC")
+        set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME ${LIB_OUTPUT_NAME} LINK_FLAGS_DEBUG "/SAFESEH:NO")
+    elseif(APPLE)
+        set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME ${LIB_OUTPUT_NAME} MACOSX_RPATH OFF)
+    else()
+        set_target_properties(${LIB_NAME} PROPERTIES OUTPUT_NAME ${LIB_OUTPUT_NAME})
+    endif()
 
 endmacro()
 
-build_lib(srcsax_static STATIC)
-build_lib(srcsax_shared SHARED)
+build_lib(srcsax_static STATIC srcsax_static)
+build_lib(srcsax_shared SHARED srcsax)
 target_link_libraries(srcsax_shared PRIVATE ${LIBXML2_LIBRARIES})
 
 install(TARGETS srcsax_shared srcsax_static RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)


### PR DESCRIPTION
Renames the static library for srcSAX to `srcsax_static` on Windows. This follows the same convention as srcML, which has `libsrcml` for its shared library and `libsrcml_static` for the static one - except that these *could* be renamed to `libsrcsax` and `libsrcsax_static`. I tested this change by using this branch for the submodule that srcDiff uses to depend on srcSAX, and building on Windows with that in place.